### PR TITLE
fix documents_for when excluding current_document

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.pythonPath": "/venv/bin/python",
-    "python.formatting.provider": "black",
+    "python.formatting.provider": "none",
     "python.formatting.blackPath": "/venv/bin/black",
     "python.formatting.blackArgs": [
         "--config=/app/pyproject.toml"
@@ -43,5 +43,8 @@
     },
     "[svelte]": {
         "editor.defaultFormatter": "svelte.svelte-vscode"
+    },
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
     }
 }

--- a/kitsune/wiki/facets.py
+++ b/kitsune/wiki/facets.py
@@ -52,7 +52,11 @@ def documents_for(locale, topics=None, products=None, current_document=None):
         url
         document_parent_id
     """
-    documents = _documents_for(locale, topics, products, current_document)
+    documents = _documents_for(locale, topics, products)
+
+    if excluding_current_document := isinstance(current_document, Document):
+        if documents and current_document.locale == locale:
+            documents = [d for d in documents if d["id"] != current_document.id]
 
     # For locales that aren't en-US, get the en-US documents
     # to fill in for untranslated articles.
@@ -61,8 +65,14 @@ def documents_for(locale, topics=None, products=None, current_document=None):
             d["document_parent_id"] for d in documents if "document_parent_id" in d
         ]
         en_documents = _documents_for(
-            locale=settings.WIKI_DEFAULT_LANGUAGE, products=products, topics=topics
+            locale=settings.WIKI_DEFAULT_LANGUAGE,
+            products=products,
+            topics=topics,
         )
+        if excluding_current_document:
+            l10n_document_ids.append(
+                current_document.parent.id if current_document.parent else current_document.id
+            )
         fallback_documents = [d for d in en_documents if d["id"] not in l10n_document_ids]
     else:
         fallback_documents = None
@@ -70,8 +80,8 @@ def documents_for(locale, topics=None, products=None, current_document=None):
     return documents, fallback_documents
 
 
-def _documents_for(locale, topics=None, products=None, current_document=None):
-    """Returns a list of articles that apply to passed in topics and products."""
+def _documents_for(locale, topics=None, products=None):
+    """Returns a list of articles that apply to passed in locale, topics and products."""
     # First try to get the results from the cache
     cache_key = _cache_key(locale, topics, products)
     documents_cache_key = f"documents_for:{cache_key}"
@@ -85,9 +95,6 @@ def _documents_for(locale, topics=None, products=None, current_document=None):
         current_revision__isnull=False,
         category__in=settings.IA_DEFAULT_CATEGORIES,
     )
-    # This is called from an existing document, so we need to exclude it
-    if current_document and isinstance(current_document, Document):
-        qs = qs.exclude(id=current_document.id)
     # speed up query by removing any ordering, since we're doing it in python:
     qs = qs.select_related("current_revision", "parent").order_by()
 

--- a/kitsune/wiki/jinja2/wiki/document.html
+++ b/kitsune/wiki/jinja2/wiki/document.html
@@ -91,7 +91,7 @@
       {{ document_content(document, fallback_reason, request, settings, document_css_class, any_localizable_revision, full_locale_name) }}
 
       {% if document.is_switching_devices_document %}
-        {{ kb_subtopic_tabs(request, switching_devices_product, switching_devices_topic, switching_devices_subtopics) }}
+        {{ kb_subtopic_tabs(request, switching_devices_product, switching_devices_topic, switching_devices_subtopics, document) }}
       {% endif %}
 
       {% set share_link = document.share_link or (document.parent and document.parent.share_link) %}

--- a/kitsune/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kitsune/wiki/jinja2/wiki/includes/document_macros.html
@@ -440,7 +440,7 @@
   </section>
 {% endmacro %}
 
-{% macro kb_subtopic_tabs(request, product, topic, subtopics) -%}
+{% macro kb_subtopic_tabs(request, product, topic, subtopics, current_document) -%}
   <nav class="tabs">
     <ul class="tabs--list subtopics">
       <li class="tabs--item">
@@ -464,7 +464,7 @@
     </ul>
   </nav>
 
-  {% set all_docs, all_fallback_docs = kb_documents_for(request.LANGUAGE_CODE, topics=[topic], products=[product])%}
+  {% set all_docs, all_fallback_docs = kb_documents_for(request.LANGUAGE_CODE, [topic], [product], current_document)%}
 
   {% if all_fallback_docs %}
     {{ kb_subtopic_documents(documents=all_fallback_docs, is_fallback=True) }}
@@ -472,7 +472,7 @@
   {{ kb_subtopic_documents(documents=all_docs) }}
 
   {% for subtopic in subtopics %}
-    {% set documents, fallback_documents = kb_documents_for(request.LANGUAGE_CODE, topics=[subtopic], products=[product])%}
+    {% set documents, fallback_documents = kb_documents_for(request.LANGUAGE_CODE, [subtopic], [product], current_document=current_document)%}
     {% if fallback_documents %}
       {{ kb_subtopic_documents(documents=fallback_docs, active_topic=subtopic.slug, is_fallback=True) }}
     {% endif %}

--- a/kitsune/wiki/templatetags/jinja_helpers.py
+++ b/kitsune/wiki/templatetags/jinja_helpers.py
@@ -20,5 +20,5 @@ def generate_video(v):
 
 
 @library.global_function
-def kb_documents_for(locale, topics=None, products=None):
-    return documents_for(locale, topics, products)
+def kb_documents_for(locale, topics=None, products=None, current_document=None):
+    return documents_for(locale, topics, products, current_document)

--- a/kitsune/wiki/tests/test_facets.py
+++ b/kitsune/wiki/tests/test_facets.py
@@ -31,7 +31,7 @@ class TestFacetHelpers(TestCase):
         doc1_revision = ApprovedRevisionFactory(document=self.doc1, is_ready_for_localization=True)
 
         self.doc1_localized = DocumentFactory(
-            locale="de", products=[], topics=[self.general_d, self.bookmarks_d], parent=self.doc1
+            locale="de", products=[], topics=[], parent=self.doc1
         )
         ApprovedRevisionFactory(document=self.doc1_localized, based_on=doc1_revision)
 
@@ -80,23 +80,23 @@ class TestFacetHelpers(TestCase):
 
     def test_documents_for(self):
         """Verify documents_for() returns documents for passed topics."""
-        # with self.subTest("documents_for-general"):
-        #     general_documents = _documents_for(locale="en-US", topics=[self.general_d])
-        #     self.assertEqual(len(general_documents), 1)
+        with self.subTest("documents_for-general"):
+            general_documents = _documents_for(locale="en-US", topics=[self.general_d])
+            self.assertEqual(len(general_documents), 1)
 
-        # with self.subTest("documents_for-bookmarks"):
-        #     bookmarks_documents = _documents_for(locale="en-US", topics=[self.bookmarks_d])
-        #     self.assertEqual(len(bookmarks_documents), 2)
+        with self.subTest("documents_for-bookmarks"):
+            bookmarks_documents = _documents_for(locale="en-US", topics=[self.bookmarks_d])
+            self.assertEqual(len(bookmarks_documents), 2)
 
-        # with self.subTest("documents_for-sync"):
-        #     sync_documents = _documents_for(locale="en-US", topics=[self.sync_d])
-        #     self.assertEqual(len(sync_documents), 1)
+        with self.subTest("documents_for-sync"):
+            sync_documents = _documents_for(locale="en-US", topics=[self.sync_d])
+            self.assertEqual(len(sync_documents), 1)
 
-        # with self.subTest("documents_for-general_bookmarks"):
-        #     general_bookmarks_documents = _documents_for(
-        #         locale="en-US", topics=[self.general_d, self.bookmarks_d]
-        #     )
-        #     self.assertEqual(len(general_bookmarks_documents), 1)
+        with self.subTest("documents_for-general_bookmarks"):
+            general_bookmarks_documents = _documents_for(
+                locale="en-US", topics=[self.general_d, self.bookmarks_d]
+            )
+            self.assertEqual(len(general_bookmarks_documents), 1)
 
         with self.subTest("documents_for-general_bookmarks-de"):
             general_bookmarks_documents_localized = _documents_for(
@@ -104,11 +104,11 @@ class TestFacetHelpers(TestCase):
             )
             self.assertEqual(len(general_bookmarks_documents_localized), 1)
 
-        # with self.subTest("documents_for-general_sync"):
-        #     general_sync_documents = _documents_for(
-        #         locale="en-US", topics=[self.general_d, self.sync_d]
-        #     )
-        #     self.assertEqual(len(general_sync_documents), 0)
+        with self.subTest("documents_for-general_sync"):
+            general_sync_documents = _documents_for(
+                locale="en-US", topics=[self.general_d, self.sync_d]
+            )
+            self.assertEqual(len(general_sync_documents), 0)
 
         with self.subTest("documents_for-bookmarks_exclude_doc1"):
             bookmarks_documents_exclude_doc1, fallbacks = documents_for(

--- a/kitsune/wiki/tests/test_facets.py
+++ b/kitsune/wiki/tests/test_facets.py
@@ -134,6 +134,30 @@ class TestFacetHelpers(TestCase):
             self.assertEqual(len(fallbacks), 1)
             self.assertEqual(fallbacks[0]["id"], self.doc2.id)
 
+    def test_documents_for_caching_1(self):
+        """
+        Ensure that when we exclude a document, it doesn't affect the result when
+        we don't. Note that the cache is automatically cleared between tests.
+        """
+        docs, _ = documents_for(
+            locale="en-US", topics=[self.bookmarks_d], current_document=self.doc1
+        )
+        self.assertEqual(len(docs), 1)
+        docs, _ = documents_for(locale="en-US", topics=[self.bookmarks_d])
+        self.assertEqual(len(docs), 2)
+
+    def test_documents_for_caching_2(self):
+        """
+        Ensure that when we don't exclude a document, it doesn't affect the result
+        when we do. Note that the cache is automatically cleared between tests.
+        """
+        docs, _ = documents_for(locale="en-US", topics=[self.bookmarks_d])
+        self.assertEqual(len(docs), 2)
+        docs, _ = documents_for(
+            locale="en-US", topics=[self.bookmarks_d], current_document=self.doc1
+        )
+        self.assertEqual(len(docs), 1)
+
     def test_documents_for_fallback(self):
         """Verify the fallback in documents_for."""
         general_bookmarks_documents, fallback = documents_for(

--- a/kitsune/wiki/tests/test_facets.py
+++ b/kitsune/wiki/tests/test_facets.py
@@ -31,7 +31,7 @@ class TestFacetHelpers(TestCase):
         doc1_revision = ApprovedRevisionFactory(document=self.doc1, is_ready_for_localization=True)
 
         self.doc1_localized = DocumentFactory(
-            locale="de", products=[], topics=[], parent=self.doc1
+            locale="de", products=[], topics=[self.general_d, self.bookmarks_d], parent=self.doc1
         )
         ApprovedRevisionFactory(document=self.doc1_localized, based_on=doc1_revision)
 
@@ -80,23 +80,23 @@ class TestFacetHelpers(TestCase):
 
     def test_documents_for(self):
         """Verify documents_for() returns documents for passed topics."""
-        with self.subTest("documents_for-general"):
-            general_documents = _documents_for(locale="en-US", topics=[self.general_d])
-            self.assertEqual(len(general_documents), 1)
+        # with self.subTest("documents_for-general"):
+        #     general_documents = _documents_for(locale="en-US", topics=[self.general_d])
+        #     self.assertEqual(len(general_documents), 1)
 
-        with self.subTest("documents_for-bookmarks"):
-            bookmarks_documents = _documents_for(locale="en-US", topics=[self.bookmarks_d])
-            self.assertEqual(len(bookmarks_documents), 2)
+        # with self.subTest("documents_for-bookmarks"):
+        #     bookmarks_documents = _documents_for(locale="en-US", topics=[self.bookmarks_d])
+        #     self.assertEqual(len(bookmarks_documents), 2)
 
-        with self.subTest("documents_for-sync"):
-            sync_documents = _documents_for(locale="en-US", topics=[self.sync_d])
-            self.assertEqual(len(sync_documents), 1)
+        # with self.subTest("documents_for-sync"):
+        #     sync_documents = _documents_for(locale="en-US", topics=[self.sync_d])
+        #     self.assertEqual(len(sync_documents), 1)
 
-        with self.subTest("documents_for-general_bookmarks"):
-            general_bookmarks_documents = _documents_for(
-                locale="en-US", topics=[self.general_d, self.bookmarks_d]
-            )
-            self.assertEqual(len(general_bookmarks_documents), 1)
+        # with self.subTest("documents_for-general_bookmarks"):
+        #     general_bookmarks_documents = _documents_for(
+        #         locale="en-US", topics=[self.general_d, self.bookmarks_d]
+        #     )
+        #     self.assertEqual(len(general_bookmarks_documents), 1)
 
         with self.subTest("documents_for-general_bookmarks-de"):
             general_bookmarks_documents_localized = _documents_for(
@@ -104,11 +104,11 @@ class TestFacetHelpers(TestCase):
             )
             self.assertEqual(len(general_bookmarks_documents_localized), 1)
 
-        with self.subTest("documents_for-general_sync"):
-            general_sync_documents = _documents_for(
-                locale="en-US", topics=[self.general_d, self.sync_d]
-            )
-            self.assertEqual(len(general_sync_documents), 0)
+        # with self.subTest("documents_for-general_sync"):
+        #     general_sync_documents = _documents_for(
+        #         locale="en-US", topics=[self.general_d, self.sync_d]
+        #     )
+        #     self.assertEqual(len(general_sync_documents), 0)
 
         with self.subTest("documents_for-bookmarks_exclude_doc1"):
             bookmarks_documents_exclude_doc1, fallbacks = documents_for(

--- a/kitsune/wiki/tests/test_facets.py
+++ b/kitsune/wiki/tests/test_facets.py
@@ -25,10 +25,12 @@ class TestFacetHelpers(TestCase):
         self.sync_m = TopicFactory(product=self.mobile, slug="sync")
 
         # Set up documents.
-        doc1 = DocumentFactory(products=[self.desktop], topics=[self.general_d, self.bookmarks_d])
-        doc1_revision = ApprovedRevisionFactory(document=doc1, is_ready_for_localization=True)
+        self.doc1 = DocumentFactory(
+            products=[self.desktop], topics=[self.general_d, self.bookmarks_d]
+        )
+        doc1_revision = ApprovedRevisionFactory(document=self.doc1, is_ready_for_localization=True)
 
-        doc1_localized = DocumentFactory(locale="de", products=[], topics=[], parent=doc1)
+        doc1_localized = DocumentFactory(locale="de", products=[], topics=[], parent=self.doc1)
         ApprovedRevisionFactory(document=doc1_localized, based_on=doc1_revision)
 
         doc2 = DocumentFactory(
@@ -97,6 +99,11 @@ class TestFacetHelpers(TestCase):
             locale="en-US", topics=[self.general_d, self.sync_d]
         )
         self.assertEqual(len(general_sync_documents), 0)
+
+        bookmarks_documents_exclude_doc1 = _documents_for(
+            locale="en-US", topics=[self.bookmarks_d], current_document=self.doc1
+        )
+        self.assertEqual(len(bookmarks_documents_exclude_doc1), 1)
 
     def test_documents_for_fallback(self):
         """Verify the fallback in documents_for."""


### PR DESCRIPTION
This turned out to be more work than I anticipated. In the end, I decided on the following:
- Leave `_documents_for()` unchanged, since it caches, and when we're excluding the current document, we shouldn't force a whole new query and cache entry just because of a single exclusion -- note that we'd have to take into account the current document's id  when creating the cache key as well if we modified `_documents_for()` to handle a document to exclude.
- Take care of the exclusion of the current document, if there is one, solely within `documents_for`
- Update the tests to cover locale cases when excluding the current document
- Add `self.subTest` context managers (just an added bonus)