### PR TITLE
possible adjustment to product classifier

### DIFF
--- a/kitsune/llm/questions/classifiers.py
+++ b/kitsune/llm/questions/classifiers.py
@@ -12,6 +12,9 @@ from kitsune.llm.questions.prompt import (
     topic_prompt,
 )
 from kitsune.llm.utils import get_llm
+
+# TODO:
+# from kitsune.products.utils import get_products, get_taxonomy
 from kitsune.products.utils import get_taxonomy
 
 DEFAULT_LLM_MODEL = "gemini-2.5-flash-preview-04-17"
@@ -60,9 +63,11 @@ def classify_question(question: "Question") -> dict[str, Any]:
             case _:
                 action = ModerationAction.NOT_SPAM
 
-        if action != ModerationAction.SPAM:
+        if not ((action == ModerationAction.SPAM) and spam_result.get("maybe_misclassified")):
             return {"action": action, "product_result": {}}
 
+        # TODO:
+        # payload["products"] = get_products(output_format="JSON")
         product_result = product_classification_chain.invoke(payload)
         new_product = product_result.get("product")
 

--- a/kitsune/llm/questions/classifiers.py
+++ b/kitsune/llm/questions/classifiers.py
@@ -3,7 +3,14 @@ from typing import TYPE_CHECKING, Any
 from django.db import models
 from langchain.schema.runnable import RunnableLambda, RunnablePassthrough
 
-from kitsune.llm.questions.prompt import spam_parser, spam_prompt, topic_parser, topic_prompt
+from kitsune.llm.questions.prompt import (
+    product_parser,
+    product_prompt,
+    spam_parser,
+    spam_prompt,
+    topic_parser,
+    topic_prompt,
+)
 from kitsune.llm.utils import get_llm
 from kitsune.products.utils import get_taxonomy
 
@@ -39,32 +46,59 @@ def classify_question(question: "Question") -> dict[str, Any]:
     }
 
     spam_detection_chain = spam_prompt | llm | spam_parser
+    product_classification_chain = product_prompt | llm | product_parser
     topic_classification_chain = topic_prompt | llm | topic_parser
+
+    def handle_spam(payload: dict[str, Any], spam_result: dict[str, Any]) -> dict[str, Any]:
+        """Handle spam classification with potential product reclassification."""
+        confidence = spam_result.get("confidence", 0)
+        match confidence:
+            case _ if confidence >= HIGH_CONFIDENCE_THRESHOLD:
+                action = ModerationAction.SPAM
+            case _ if confidence > LOW_CONFIDENCE_THRESHOLD:
+                action = ModerationAction.FLAG_REVIEW
+            case _:
+                action = ModerationAction.NOT_SPAM
+
+        if action != ModerationAction.SPAM:
+            return {"action": action, "product_result": {}}
+
+        product_result = product_classification_chain.invoke(payload)
+        new_product = product_result.get("product")
+
+        if new_product and new_product != payload["product"]:
+            payload["product"] = new_product
+            payload["topics"] = get_taxonomy(
+                new_product, include_metadata=["description", "examples"], output_format="JSON"
+            )
+            topic_result = topic_classification_chain.invoke(payload)
+            return {
+                "action": ModerationAction.NOT_SPAM,
+                "product_result": product_result,
+                "topic_result": topic_result,
+            }
+        else:
+            return {
+                "action": ModerationAction.SPAM,
+                "product_result": product_result,
+            }
 
     def decision_lambda(payload: dict[str, Any]) -> dict[str, Any]:
         spam_result: dict[str, Any] = payload["spam_result"]
-        confidence: int = spam_result.get("confidence", 0)
         is_spam: bool = spam_result.get("is_spam", False)
-        result = {
-            "action": ModerationAction.NOT_SPAM,
+
+        base_result = {
             "spam_result": spam_result,
+            "product_result": {},
             "topic_result": {},
         }
 
         if is_spam:
-            match confidence:
-                case _ if confidence >= HIGH_CONFIDENCE_THRESHOLD:
-                    result["action"] = ModerationAction.SPAM
-                case _ if (
-                    confidence > LOW_CONFIDENCE_THRESHOLD
-                    and confidence < HIGH_CONFIDENCE_THRESHOLD
-                ):
-                    result["action"] = ModerationAction.FLAG_REVIEW
+            spam_handling = handle_spam(payload, spam_result)
+            return {**base_result, **spam_handling}
 
-        if result["action"] == ModerationAction.NOT_SPAM:
-            result["topic_result"] = topic_classification_chain.invoke(payload)
-
-        return result
+        topic_result = topic_classification_chain.invoke(payload)
+        return {**base_result, "topic_result": topic_result}
 
     pipeline = RunnablePassthrough.assign(spam_result=spam_detection_chain) | RunnableLambda(
         decision_lambda

--- a/kitsune/llm/questions/prompt.py
+++ b/kitsune/llm/questions/prompt.py
@@ -16,7 +16,7 @@ A question is spam if **at least one** of these criteria applies:
 - Encourages illegal, unethical, or dangerous behavior.
 - Promotes political views or propaganda unrelated to the product.
 - Is extremely short (e.g., less than 10 words), overly vague, or the primary purpose of the question cannot be understood from the text.
-- Intent or relevance to Mozilla's "{product}" cannot be determined.
+- Its intent cannot be determined.
 - Contains excessive random symbols, emojis, or gibberish text.
 - Contains QR codes or links/images directing users off-site.
 - Clearly unrelated to Mozilla's "{product}" product features, functionality or purpose.
@@ -29,6 +29,7 @@ Given a user question, follow these steps:
    - `0` = Extremely uncertain.
    - `100` = Completely certain.
 4. Provide a concise explanation supporting your decision.
+5. **Determine if the question may have been classified under the wrong product:** This should be true if and only if the question represents a legitimate support request, **and** the **sole** reason for classifying the question as spam is because it's clearly unrelated to Mozilla's "{product}" product.
 
 # Response format
 {format_instructions}
@@ -142,6 +143,11 @@ spam_parser = StructuredOutputParser.from_response_schemas(
             name="reason",
             type="str",
             description="The reason for identifying the question as spam or not spam.",
+        ),
+        ResponseSchema(
+            name="maybe_misclassified",
+            type="bool",
+            description="A boolean that when true indicates that the question may be classified under the wrong product",
         ),
     )
 )


### PR DESCRIPTION
I thought this was a nice way to have the spam classifier maintain its sharp focus, but also provide a little extra information that we could use to be more precise as to when it's worth running a product re-classification.

It seemed to me that the only time when we should investigate a possible product misclassification is when the spam classifier has marked the question as spam for the sole reason that the question was not relevant to the original product it was classified under.